### PR TITLE
VIH-10352 Send created account email to johs

### DIFF
--- a/NotificationApi/NotificationApi.IntegrationTests/Api/ParticipantNotifications/SendParticipantCreatedAccountEmailTests.cs
+++ b/NotificationApi/NotificationApi.IntegrationTests/Api/ParticipantNotifications/SendParticipantCreatedAccountEmailTests.cs
@@ -96,5 +96,36 @@ namespace NotificationApi.IntegrationTests.Api.ParticipantNotifications
                                                && x.ExternalRefId == notifications[0].ExternalId 
             ).Should().BeTrue();
         }
+
+        [Test]
+        public async Task should_send_a_created_account_email_for_a_judicial_office_holder()
+        {
+            // arrange
+            var request = new SignInDetailsEmailRequest
+            {
+                RoleName = RoleNames.JudicialOfficeHolder,
+                ContactEmail = $"{Guid.NewGuid()}@test.com",
+                Name = $"{Faker.Name.FullName()}",
+                Username = $"{Guid.NewGuid()}@test.com",
+                Password = $"{Faker.RandomNumber.Next()}",
+            };
+        
+            // act
+            using var client = Application.CreateClient();
+            var result = await client.PostAsync(
+                ApiUriFactory.ParticipantNotificationEndpoints.SendParticipantCreatedAccountEmail, RequestBody.Set(request));
+
+
+            // assert
+            result.IsSuccessStatusCode.Should().BeTrue(result.Content.ReadAsStringAsync().Result);
+
+            var notifications = await TestDataManager.GetNotifications(null, null,
+                Domain.Enums.NotificationType.CreateRepresentative, request.ContactEmail);
+            notifications.Count.Should().Be(1);
+            _notifyStub.SentEmails.Count.Should().Be(1);
+            _notifyStub.SentEmails.Exists(x => x.EmailAddress == request.ContactEmail 
+                                               && x.ExternalRefId == notifications[0].ExternalId 
+            ).Should().BeTrue();
+        }
     }
 }

--- a/NotificationApi/NotificationApi/Controllers/ParticipantEmailNotificationsController.cs
+++ b/NotificationApi/NotificationApi/Controllers/ParticipantEmailNotificationsController.cs
@@ -35,6 +35,7 @@ namespace NotificationApi.Controllers
             {
                 RoleNames.Individual => NotificationType.CreateIndividual,
                 RoleNames.Representative => NotificationType.CreateRepresentative,
+                RoleNames.JudicialOfficeHolder => NotificationType.CreateRepresentative,
                 _ => throw new BadRequestException($"Provided role is not {request.RoleName}")
             };
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/VIH-10352


### Change description ###
Fixes an issue where new account emails are not sent to johs. Reinstate this functionality, using the Representative email template.

In case it's not clear from the changes - a new test has been added (`should_send_a_created_account_email_for_a_judicial_office_holder()`) with the same assertions as 
`should_send_a_created_account_email_for_a_representative()`