### PR TITLE
VIH-11002 remove manual approval from demo env

### DIFF
--- a/azure-pipelines.sds.master-release.yml
+++ b/azure-pipelines.sds.master-release.yml
@@ -22,7 +22,6 @@ parameters:
     publishNuget: true
     pushHelmChart: true
   - env: 'demo'
-    requireApproval: true
     buildPushImage: false
     publishNuget: false
     pushHelmChart: false


### PR DESCRIPTION
### Jira link
See [VIH-11002](https://tools.hmcts.net/jira/browse/VIH-11002)

### Change description

Removes manual approval step by default for Demo env, as Demo uses Dev image tag for Flux, so Entity Framework also needs to auto-deploy to Demo when Dev auto-deploys.